### PR TITLE
Update stream-python version on requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytz==2014.10
 requests==2.5.1
 six==1.9.0
 stream-django==1.2.0
-stream-python==2.1.4
+stream-python==2.3.4
 whitenoise==1.0.6
 autopep8
 django-allauth==0.19.1


### PR DESCRIPTION
Updating stream-python version on requirements.txt to 2.3.4. The previous version (2.1.4) was raising a "GetStreamAPI403" exception.