### PR TITLE
fixed bug: Does not allow unfollow if multiple users follow target

### DIFF
--- a/stream_twitter/views.py
+++ b/stream_twitter/views.py
@@ -73,7 +73,7 @@ class UnfollowView(DeleteView):
 
     def get_object(self):
         target_id = self.kwargs['target_id']
-        return self.get_queryset().get(target__id=target_id)
+        return self.get_queryset().get(target__id=target_id, user=self.request.user)
 
 
 class DiscoverView(TemplateView):


### PR DESCRIPTION
I noticed that if multiple users are following a target user and one of them tries to unfollow said target user, you get an error:

`stream_twitter.models.MultipleObjectsReturned: get() returned more than one Follow -- it returned 2!
`

Which came from the UnfollowView class in stream-twitter/views.py line 76:

`        return self.get_queryset().get(target__id=target_id)
`

So I changed it to:

`        return self.get_queryset().get(target__id=target_id, user=self.request.user)
`

Which seems to work...